### PR TITLE
fixed compile error cant narrow type in initializer list

### DIFF
--- a/m6800/src/mem.cpp
+++ b/m6800/src/mem.cpp
@@ -45,10 +45,9 @@ namespace Emulator
     }
 
     void Memory::writeWord(uint16_t addr, uint16_t data) {
-        uint8_t bytes[2]{
-            (data >> 0) & 0xFF,
-           (data >> 8) & 0xFF
-        };
+        uint8_t bytes[2];
+        bytes[0] = (data >> 0) & 0xFF;
+        bytes[1] = (data >> 8) & 0xFF;
         this->data[addr] = bytes[1];
         this->data[addr + 1] = bytes[0];
     }


### PR DESCRIPTION
The explanation for the change since this is not seen on Windows or in CI report. When compiling on wls debian and gcc (Debian 10.2.1-6) 10.2.1 20210110 and in Ubuntu 20.04 machine with gcc version 9.4.0 i got errors 
`m6800/src/mem.cpp:50:12: error: non-constant-expression cannot be narrowed from type 'int' to 'uint8_t' (aka 'unsigned char') in initializer list [-Wc++11-narrowing]
   50 |            (data >> 8) & 0xFF
      |            ^~~~~~~~~~~~~~~~~~ `